### PR TITLE
Attempt at supporting shorter syntax

### DIFF
--- a/src/Epitath.re
+++ b/src/Epitath.re
@@ -1,1 +1,2 @@
-let let_ = (children, render) => children(render);
+let let_ = (make, children) =>
+  ReasonReact.element(~key=?None, ~ref=?None, make(children));


### PR DESCRIPTION
Fixes #1 

This is just an exploration, to test the limitations of what could be achieved. The problem with the JSX syntax is that using JSX calls `ReasonReact.element`, which means `bs-epitath` doesn't get the opportunity to pass in the render prop function, hence why currently the user must declare a function.

In this attempt, I assumed 2 limitations:

1. The user shouldn't need to use a function declaration in the `let%Epitath` binding (i.e. we are aiming at a shorter syntax).
2. We can only use the `let-anything` ppx, we musn't require a further ppx.

The only solution I could think of was this PR, where the user simply passes the component's make function and it's up to `bs-epitath` to call `ReasonReact.element` with that make function and also pass in the render prop function. (NB I switched round the meaning of `children` in this PR because it didn't make sense to me that `children` referred to the render prop component and `render` referred to the `children` function!).

This is the diff of usage:

```reason
// before
let%Epitath {pageX, pageY} = children => <OnLayout> ...children </OnLayout>;

// after this PR
let%Epitath {pageX, pageY} = OnLayout.make;
```

There are 2 issues with this solution, however:

1. It doesn't use JSX syntax, which means it's not as intuitive. As I say above, I can't see a way around this.
2. It doesn't currently offer a way to pass props to the render prop component other than the `children` prop. There might be a way around this!